### PR TITLE
# Version 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 DB2
 =========
 
-
 Simple role to install IBM DB2 
-[![Build Status](https://travis-ci.org/bernardoVale/ansible-role-db2.svg?branch=master)](https://travis-ci.org/bernardoVale/ansible-role-db2)
 
 Requirements
 ------------
@@ -22,50 +20,50 @@ Role Variables
 
 This hash controls how to send the DB2 binary to the remote hosts.
 
-**db2_binary.url**: A URL to download db2 License (don't set this if you want to use a local copy)
+- **db2_binary.url**: A URL to download db2 License (don't set this if you want to use a local copy)
+- **db2_binary.location**: A path to save the remote file or to get the file if url wasn't defined
+- **db2_binary.dest**: Where the role should decompress DB2 on remote host.
 
-**db2_binary.location**: A path to save the remote file or to get the file if url wasn't defined
+```yaml
+db2_binary:
+    url: https://mycompany.com/downloads/db2_11_5.tar.gz
+    location: /ansible/files/db2_11.5.tar.gz
+    dest: /tmp
+````
 
-**db2_binary.dest**: Where the role should decompress DB2 on remote host.
-
-
-    db2_binary:
-        url: https://mycompany.com/downloads/db2_11_1.tar.gz
-        location: /ansible/files/db2_11.1.tar.gz
-        dest: /tmp
-
- Check how to download DB2 from a remote URL [here](https://github.com/bernardoVale/ansible-role-db2/tree/master/examples/downloading_db2.yml)
+Check how to download DB2 from a remote URL [here](https://github.com/bernardoVale/ansible-role-db2/tree/master/examples/downloading_db2.yml)
  
- If you have a local copy use this [example](https://github.com/bernardoVale/ansible-role-db2/tree/master/examples/local_db2.yml)
+If you have a local copy use this [example](https://github.com/bernardoVale/ansible-role-db2/tree/master/examples/local_db2.yml)
 
 
 ###DB2_BINARY_LICENSE
 
- For the Spectrum Scale DB2 License package:
+For the Spectrum Scale DB2 License package:
 
-**db2_license_binary.url**: A URL to download db2 (don't set this if you want to use a local copy)
+- **db2_license_binary.url**: A URL to download db2 (don't set this if you want to use a local copy)
+- **db2_license_binary.location**: A path to save the remote file or to get the file if url wasn't defined
+- **db2_license_binary.dest**: Where the role should decompress DB2 on remote host.
 
-**db2_license_binary.location**: A path to save the remote file or to get the file if url wasn't defined
-
-**db2_license_binary.dest**: Where the role should decompress DB2 on remote host.
-
-    db2_license_binary:
-      url: "https://mycompany.com/downloads/DB2_AWSE_Restricted_Activation_11.1.zip"
-      location: "/download/installer/db2_license.tar.gz"
-      dest: "/download/installer
-
+````yaml
+db2_license_binary:
+  url: "https://mycompany.com/downloads/DB2_AWSE_Restricted_Activation_11.5.zip"
+  location: "/download/installer/db2_license.tar.gz"
+  dest: "/download/installer
+````
 
 ###DB2_CREATES
 
 The DB2 tar.gz usually creates a folder named `server`, but there are some binaries that creates different folders, for example DB2 Express C create a folder named `expc`. If your tar.gz creates a different folder, change this variable. For example:
-
-    db2_creates: expc
+```yaml
+db2_creates: 'expc'
+```
 
 ###DB2_LICENSE_CREATES
 The DB2 tar.gz usually creates a folder named `awse_x`, but there are some binaries that creates different folders, If your tar.gz creates a different folder, change this variable. For example:
 
-    db2_license_creates: 'awse_o'
-  
+```yaml
+db2_license_creates: 'awse_o'
+```
   
 ###DB2_PACKAGES
 
@@ -78,29 +76,28 @@ DB2 requires some packages to run properly on Linux, you can read more about thi
 
 This hash is used to customize the DB2 installation.
 
-**prod:** Witch product will be installed
+- **prod:** Witch product will be installed
+- **file:** Where should install DB2
+- **lic_agreement:** Accept or decline the license (If decline the DB2 won't be installed)
+- **install_type:** Customizations of the products that will be installed
 
-**file:** Where should install DB2
-
-**lic_agreement:** Accept or decline the license (If decline the DB2 won't be installed)
-
-**install_type:** Customizations of the products that will be installed
-
-    resp:
-       prod: "DB2_SERVER_EDITION"
-       file: "/opt/ibm/db2/V11.1"
-       lic_agreement: "ACCEPT" # ACCEPT or DECLINE
-       install_type: "TYPICAL" # TYPICAL, COMPACT, CUSTOM
-       install_tsamp: "NO"
-
+```yaml
+resp:
+   prod: "DB2_SERVER_EDITION"
+   file: "/opt/ibm/db2/V11.1"
+   lic_agreement: "ACCEPT" # ACCEPT or DECLINE
+   install_type: "TYPICAL" # TYPICAL, COMPACT, CUSTOM
+   install_tsamp: "NO"
+```
 For **DB2 Express-C** (Check this [file](https://github.com/bernardoVale/ansible-role-db2/tree/master/examples/db2_express-c_example.yml) ):
 
-     resp:
-       prod: "EXPRESS_C"
-       file: "/opt/ibm/db2/V11.1"
-       lic_agreement: "ACCEPT" # ACCEPT or DECLINE
-       install_type: "TYPICAL" # TYPICAL, COMPACT, CUSTOM
-
+```yaml
+ resp:
+   prod: "EXPRESS_C"
+   file: "/opt/ibm/db2/V11.1"
+   lic_agreement: "ACCEPT" # ACCEPT or DECLINE
+   install_type: "TYPICAL" # TYPICAL, COMPACT, CUSTOM
+```
       
 **NOTE**: By using this role, you're accepting [IBM license](http://www-03.ibm.com/software/sla/sladb.nsf/search/).
 
@@ -115,21 +112,25 @@ All custom options are provided through an example file on [examples folder](htt
 
 You need at least specify where to get DB2. [Downloading db2](https://github.com/bernardoVale/ansible-role-db2/tree/master/examples/downloading_db2.yml)
 
-    - hosts: servers
-      roles:
-         - db2
-      vars:
-        db2_binary:
-          location: /ansible/files/db2_11.1.tar.gz
-           dest: /tmp
+```yaml
+- hosts: servers
+  roles:
+     - db2
+  vars:
+    db2_binary:
+      location: /ansible/files/db2_11.1.tar.gz
+       dest: /tmp
+```
 
 ###Installing DB2 without instances
 
 In some cases, such as cluster failover deployment, you may wish to install only DB2 software and not create any instances.
 This can be achieved by specifying the `create_instances: false` variable like shown below.
 
-    vars:
-      create_instances: false
+```yaml
+vars:
+  create_instances: false
+```
 
 The full example [here](https://github.com/bernardoVale/ansible-role-db2/tree/master/examples/db2_without_instances.yml)
 
@@ -139,13 +140,15 @@ The instance will be created using all DB2 defaults, but you can customize it us
 
 The full example [here](https://github.com/bernardoVale/ansible-role-db2/tree/master/examples/custom_instance.yml)
 
-    db2_instances:
-         - instance: "DB2INST"
-           name: "myinstan" 
-           group_name: "myinadm"
-           fenced_username: "myfenc1"
-           fenced_group_name: "myfadm1"
-           
+```yaml
+db2_instances:
+  - instance: "DB2INST"
+    name: "myinstan" 
+    group_name: "myinadm"
+    fenced_username: "myfenc1"
+    fenced_group_name: "myfadm1"
+```
+     
 **db2_instances** is a list of instances, you can create more than one, an example of two instances is found [here](https://github.com/bernardoVale/ansible-role-db2/tree/master/examples/multiples_instances.yml)
 
 ###Customizing Parameters
@@ -154,26 +157,30 @@ Both global and instance parameters can be customized.
 
 Define hash `dbm_params` and set any `key: value` DB2 parameter. The key must be a valid DB2 parameter.
 
-    db2_instances:
-        - instance: "DB2INST"
-          name: "myinstan" 
-          group_name: "myinadm"
-          fenced_username: "myfenc1"
-          fenced_group_name: "myfadm1"
-          dbm_params:
-            intra_parallel: "YES"
-            numdb: "20"
-            
+```yaml
+db2_instances:
+ - instance: "DB2INST"
+   name: "myinstan" 
+   group_name: "myinadm"
+   fenced_username: "myfenc1"
+   fenced_group_name: "myfadm1"
+   dbm_params:
+     intra_parallel: "YES"
+     numdb: "20"
+```
+  
 The full example [here](https://github.com/bernardoVale/ansible-role-db2/tree/master/examples/instance_with_custom_params.yml)
 
 ### Global parameters
 
 Global parameters are provided by defining `global_params` hash.
 
-    global_params:
-        db2_antijoin: "YES"
-        db2fcmcomm: "TCPIP4"
- 
+```yaml
+global_params:
+    db2_antijoin: "YES"
+    db2fcmcomm: "TCPIP4"
+```
+
  The full example [here](https://github.com/bernardoVale/ansible-role-db2/tree/master/examples/global_profile.yml)
         
 
@@ -183,15 +190,16 @@ By default this role won't create databases, if you want to, define the hash lis
 
 The full example is found [here](https://github.com/bernardoVale/ansible-role-db2/tree/master/examples/databases.yml)
 
-    databases:
-        - name: mydb
-          instance: db2inst1
-        - name: otherdb
-          instance: db2inst2
-          codeset: "UTF-8"
-          territory: "en"
-          pagesize: "16384"
- 
+```yaml
+databases:
+ - name: mydb
+   instance: db2inst1
+ - name: otherdb
+   instance: db2inst2
+   codeset: "UTF-8"
+   territory: "en"
+   pagesize: "16384"
+```
 
 Disclaimer
 ---------
@@ -208,4 +216,4 @@ BSD
 
 Author Information
 ------------------
-[Bernardo Vale](https://github.com/bernardoVale)
+Originally [Bernardo Vale](https://github.com/bernardoVale)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,32 +1,58 @@
 ---
 # On most DB2 compressed binary the tar.gz creates a file named server, but if your compressed file doesn't, change this variable to the name of the folder that it creates.
-db2_creates: server
-db2_license_creates: awse_o
-#
-db2_packages:
- - pam
- - pam-devel.i686
- - libaio
- - compat-libstdc++-33.i686
- - compat-libstdc++-33
- - libstdc++-devel.i686
- - libstdc++
- - ksh
- - unzip
+db2_creates: server_dec
+db2_license_creates: std_vpc
+db2_license_filename: db2std_vpc.lic
+
+# Vars is in folder /vars/os
+#db2_packages:
+# - pam
+# - pam-devel.i686
+# - libaio
+# - compat-libstdc++-33.i686
+# - compat-libstdc++-33
+# - libstdc++-devel.i686
+# - libstdc++
+# - ksh
+# - unzip
+# - libselinux-python3
+
+# https://www.ibm.com/docs/en/db2/11.5?topic=servers-linux
+# Rhel 8.x
+#db2_packages:
+# - libaio
+# - ksh
+# - libstdc++.so.6
+# - unzip
+# - libselinux-python3
+
+# - libstdc++ Contains libstdc++.so.6 that is not required for Linux on POWER® or SLES 11.
+# - libxlc Contains libibmc++.so.1 (64 bit only) that is required for Linux on POWER little endian.
 
 yum_repo: http://public-yum.oracle.com/public-yum-ol7.repo
+
 #Check download_db2.yml  to find how you can use this role to download a DB2 from a remote repo
 db2_binary:
   location: "/vagrant/tests/db2_10503.tar.gz"
   dest: "/tmp"
 
-# Response file keywords: https://www-01.ibm.com/support/knowledgecenter/SSEPGG_10.5.0/com.ibm.db2.luw.qb.server.doc/doc/r0007505.html
+# Removing DB2 Community License
+db2_license_remove_community: true
+db2_community_product_identifier: "db2dec"
+
+# SELinux - Disabling or Put in permissive mode, logging actions that would be blocked.
+db2_selinux_state: "permissive"
+
+# Response file keywords: https://www.ibm.com/docs/en/db2/11.5?topic=file-response-keywords
 resp:
   prod: "DB2_SERVER_EDITION"
-  file: "/opt/ibm/db2/V11.1"
+  file: "/opt/ibm/db2/V11.5"
   lic_agreement: "ACCEPT" # ACCEPT or DECLINE
   install_type: "TYPICAL" # TYPICAL, COMPACT, CUSTOM
   install_tsamp: "NO"
+
+# location for DB2 respons file
+db2_respons_locations: "/tmp/db2server.rsp"
 
 # This controls if the role should cache yum/apt
 make_cache: no

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,12 +14,12 @@ galaxy_info:
   # - Apache
   # - CC-BY
   license: BSD
-  min_ansible_version: 2.0
+  min_ansible_version: 2.9
   platforms:
   - name: EL
     versions:
-     - 6
      - 7
+     - 8
   - name: Ubuntu
     versions:
      - all

--- a/tasks/create_databases.yml
+++ b/tasks/create_databases.yml
@@ -1,23 +1,23 @@
 ---
-  - name: Create Databases
-    db2:
-      name: "{{ item.name }}"
-      instance: "{{ item.instance }}"
-      path: "{{ item.path | default() }}"
-      automatic: "{{ item.automatic | default('YES') }}"
-      pagesize: "{{ item.pagesize | default() }}"
-      codeset: "{{ item.codeset | default() }}"
-      territory: "{{ item.territory | default() }}"
-    register: db_debug
-    become: True
-    become_user: "{{ item.instance }}"
-    become_method: sudo
-    vars: #Pipelining it's great but doesn't work with sudo
-      ansible_pipelining: False
-    with_items: "{{ databases }}"
+- name: Create Databases
+  db2:
+    name: "{{ item.name }}"
+    instance: "{{ item.instance }}"
+    path: "{{ item.path | default() }}"
+    automatic: "{{ item.automatic | default('YES') }}"
+    pagesize: "{{ item.pagesize | default() }}"
+    codeset: "{{ item.codeset | default() }}"
+    territory: "{{ item.territory | default() }}"
+  register: db_debug
+  become: True
+  become_user: "{{ item.instance }}"
+  become_method: sudo
+  vars: #Pipelining it's great but doesn't work with sudo
+    ansible_pipelining: False
+  loop: "{{ databases }}"
 
-
-  - name: Create Database Log
-    debug: var=db_debug
-    when: db_debug|changed
-    changed_when: false
+- name: Create Database Log
+  debug:
+    var: db_debug
+  when: db_debug|changed
+  changed_when: false

--- a/tasks/instance_users.yml
+++ b/tasks/instance_users.yml
@@ -2,20 +2,21 @@
 # As mentioned by IBM if you set password,uid,gid,group_name 
 # If you provide at least user,password and group_name DB2 setup will create those users
 # TODO: Use the new block feature since `when` clause is equal on all tasks
-- name: Creating DB2 Fenced Groups
+- name: Instance | Creating DB2 Fenced Groups
   group:
     name: "{{ item.fenced_group_name }}"
     gid: "{{ item.gid | default(omit) }}"
     state: present
-  with_items: "{{ db2_instances }}"
-- name: Creating DB2 Instance Groups
+  loop: "{{ db2_instances }}"
+
+- name: Instance | Creating DB2 Instance Groups
   group:
     name: "{{ item.group_name }}"
     gid: "{{ item.fenced_gid | default(omit) }}"
     state: present
-  with_items: "{{ db2_instances }}"
+  loop: "{{ db2_instances }}"
 
-- name: Creating DB2 Instance Users
+- name: Instance | Creating DB2 Instance Users
   user:
     name: "{{ item.name }}"
     group: "{{ item.group_name }}"
@@ -23,9 +24,10 @@
     home: "{{ item.home_directory | default(omit) }}"
     uid: "{{ item.uid | default(omit) }}"
     createhome: "{{ item.createhome | default(true) }}"
-  with_items: "{{ db2_instances }}"
+    shell: /bin/bash
+  loop: "{{ db2_instances }}"
 
-- name: Creating DB2 Fenced Users
+- name: Instance | Creating DB2 Fenced Users
   user:
     name: "{{ item.fenced_username }}"
     group: "{{ item.fenced_group_name }}"
@@ -33,5 +35,6 @@
     home: "{{ item.fenced_home_directory | default(omit) }}"
     uid: "{{ item.fenced_uid | default(omit) }}"
     createhome: "{{ item.createhome | default(true) }}"
-  with_items: "{{ db2_instances }}"
+    shell: /bin/bash
+  loop: "{{ db2_instances }}"
   register: db2_fenced_user

--- a/tasks/license_db2.yml
+++ b/tasks/license_db2.yml
@@ -4,6 +4,13 @@
   shell: "{{ resp.file }}/adm/db2licm -l | grep Expiry"
   register: db2license_expiry
   changed_when: false
+  failed_when: false
+
+- name: License DB2 | Check if license type is Community
+  shell: "{{ resp.file }}/adm/db2licm -l | grep Community"
+  register: db2license_community
+  changed_when: false
+  failed_when: false
 
 - block:
   - name: License DB2 | Downloading DB2 license file
@@ -20,6 +27,12 @@
       remote_src: yes
 
   - name: License DB2 | Add DB2 license #todo check that awse_o is the standard
-    command: '"{{ resp.file }}/adm/db2licm" -a "{{ db2_license_binary.dest }}/{{ db2_license_creates }}/db2/license/db2awse_o.lic"'
+    command: '"{{ resp.file }}/adm/db2licm" -a "{{ db2_license_binary.dest }}/{{ db2_license_creates }}/db2/license/{{ db2_license_filename }}"'
     register: db2_license_add
-  when: "'Permanent' not in db2license_expiry.stdout"
+  when:
+    - "'Permanent' not in db2license_expiry.stdout or 'Community' in db2license_community.stdout"
+
+- name: License DB2 | Remove Community DB2 license
+  command: '"{{ resp.file }}/adm/db2licm" -r "{{ db2_community_product_identifier }}"'
+  register: db2_license_remove
+  when: "db2_license_remove_community | bool and 'Community' in db2license_community.stdout"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,71 +1,75 @@
 ---
-  # Include variables at the start so they're in scope
-  - name: Include OS-Specific variables
-    include_vars: "{{ ansible_os_family }}.yml"
+# Include variables at the start so they're in scope
+- name: Include OS-Specific variables
+  include_vars: "{{ ansible_os_family }}.yml"
 
-  - include: get_db2.yml
-    tags: download
+- include: get_db2.yml
+  tags: download
 
-  - include: packages-redhat.yml
-    when: ansible_os_family == "RedHat"
+- include: packages-redhat.yml
+  when: ansible_os_family == "RedHat"
 
-  - include: packages-debian.yml
-    when: ansible_os_family == "Debian"
+- include: packages-debian.yml
+  when: ansible_os_family == "Debian"
 
-  - include: instance_users.yml
-    tags: ['users', 'setup']
+- include: instance_users.yml
+  tags: ['users', 'setup']
 
-  - name: Disabling SELinux
-    selinux: state=disabled
-    tags: ['dont-on-docker', 'setup']
-    when: ansible_os_family == "RedHat"
+- name: SELinux - Disabling or Put in permissive mode, logging actions that would be blocked.
+  selinux:
+    state: "{{ db2_selinux_state }}"
+    policy: targeted
+  tags: ['dont-on-docker', 'setup']
+  when: ansible_os_family == "RedHat"
 
-  - name: Adding entry to /etc/hosts
-    lineinfile:
-      dest: /etc/hosts
-      regexp: "^{{ ansible_default_ipv4.address }} {{ ansible_hostname }}$"
-      line: "{{ ansible_default_ipv4.address }} {{ ansible_hostname }}"
-    tags: ['dont-on-docker', 'setup']
+- name: Adding entry to /etc/hosts
+  lineinfile:
+    dest: /etc/hosts
+    regexp: "^{{ ansible_default_ipv4.address }} {{ ansible_hostname }}$"
+    line: "{{ ansible_default_ipv4.address }} {{ ansible_hostname }}"
+  tags: ['dont-on-docker', 'setup']
 
-  - name: Running DB2 Pre Requisits Check
-    command: "{{ db2_binary.dest }}/{{ db2_creates }}/db2prereqcheck -i -s"
-    register: precheck
-    failed_when: "'failed' in precheck.stderr"
-    changed_when: False
-    tags: setup
+- name: Running DB2 Pre Requisits Check
+  command: "{{ db2_binary.dest }}/{{ db2_creates }}/db2prereqcheck -i -s"
+  register: precheck
+  failed_when: "'failed' in precheck.stderr"
+  changed_when: False
+  tags: setup
 
-  - name: Parse response file
-    template:
-     src: db2server.j2.rsp
-     dest: /tmp/db2server.rsp
-    tags: parse
+- name: Parse response file
+  template:
+   src: db2server.j2.rsp
+   dest: "{{ db2_respons_locations }}"
+  tags: parse
 
-  - name: Installing DB2 #todo add version variable
-    command: "{{ db2_binary.dest }}/{{ db2_creates }}/db2setup -r /tmp/db2server.rsp"
-    register: db2_setup
-    args:
-      creates: "{{ resp.file }}"
-    tags: install
+- name: Installing DB2 #todo add version variable
+  command: "{{ db2_binary.dest }}/{{ db2_creates }}/db2setup -r {{ db2_respons_locations }}"
+  register: db2_setup
+  args:
+    creates: "{{ resp.file }}"
+  tags: install
 
-  - name: Setup results
-    debug: var=db2_setup
-    tags: download
+- name: Setup results
+  debug:
+    var: db2_setup
+  tags: download
 
-  - name: Validating the current installation
-    command: "{{ resp.file }}/bin/db2val -o"
-    register: db2_val
-    failed_when: "'DBI1335I' not in db2_val.stdout"
-    changed_when: False
-    tags: ['install', 'validate']
+- name: DB2 - Validating the current installation
+  command: "{{ resp.file }}/bin/db2val -o"
+  register: db2_val
+  failed_when: "'DBI1335I' not in db2_val.stdout"
+  changed_when: False
+  tags: ['install', 'validate']
 
-  - name: Validate results
-    debug: var=db2_val
-    tags: download
+- name: Validate results
+  debug:
+    var: db2_val
+  tags: download
 
-  - include: create_databases.yml
-    when: databases is defined
-    tags: databases
+- include: create_databases.yml
+  when: databases is defined
+  tags: databases
 
-  - import_tasks: license_db2.yml
-    tags: licensedb2
-    when: db2_binary.url is defined
+- import_tasks: license_db2.yml
+  tags: licensedb2
+  when: db2_binary.url is defined

--- a/tasks/packages-debian.yml
+++ b/tasks/packages-debian.yml
@@ -12,5 +12,8 @@
     tags: ['packages', 'setup']
 
   - name: Fixing Libpam
-    file: path=/lib/libpam.so src=/lib/i386-linux-gnu/libpam.so.0 state=link
+    file:
+      path: /lib/libpam.so
+      src: /lib/i386-linux-gnu/libpam.so.0
+      state: link
     tags: setup

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -7,5 +7,7 @@ db2_packages:
  - libpam0g
  - lib32stdc++6
  - libpam0g:i386
+ - binutils
+ - libaio1
 
 make_cache: yes

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,5 +1,6 @@
 ---
-db2_packages:
+# not used anymore
+db2_packages_el7:
  - pam
  - pam-devel.i686
  - libaio
@@ -9,3 +10,11 @@ db2_packages:
  - unzip
  - numactl
  - libselinux-python
+
+# For rhel 8 : # https://www.ibm.com/docs/en/db2/11.5?topic=servers-linux
+db2_packages:
+ - libaio
+ - ksh
+ - libstdc++.so.6
+ - unzip
+ - libpam.so.0


### PR DESCRIPTION
- Tested on Rhel 8.5 with Spectrum Control 5.4.5 and DB2 11.5.4
- Changed ansible modules from With_item to loop. Selinux with permissive.
- Added more variables that could be changed, default in main/default.
- Changed and added db2 prereq packages for Rhel 8.x
- Added check for license is community, and add license.
- Changed default db2_creates = server_dec, and license creates std_vpc. and db2 license filename: db2std_vpc_lic
- Cleand up some of the readme.

Signed-off-by: Ole Kristian <ole.kr.myklebust@gmail.com>